### PR TITLE
OPHJOD-2289: Add service banner to header

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1254,7 +1254,7 @@
     },
     "node_modules/@jod/design-system": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/Opetushallitus/jod-design-system.git#09f86e299fd299fcf6c8065373dc96bd461db1db",
+      "resolved": "git+ssh://git@github.com/Opetushallitus/jod-design-system.git#60614322e06608fc0797a69fdbdcd21f7999cf16",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ark-ui/react": "^5.18.3",

--- a/src/i18n/fi/translation.json
+++ b/src/i18n/fi/translation.json
@@ -847,6 +847,7 @@
   },
   "return-home": "Palaa etusivulle",
   "select-language": "Valitse kieli",
+  "service-banner": "Palvelukokonaisuus",
   "show-all": "Näytä kaikki",
   "skiplinks": {
     "main": "Siirry pääsisältöön"

--- a/src/routes/Root/Root.tsx
+++ b/src/routes/Root/Root.tsx
@@ -140,6 +140,9 @@ const Root = () => {
               {children as React.ReactNode}
             </Link>
           )}
+          showServiceBar
+          serviceBarVariant="palveluportaali"
+          serviceBarTitle={t('service-banner')}
         />
         <NoteStack showAllText={t('show-all')} />
       </header>


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->
Add "Palvelukokonaisuus" service banner 


<img width="1246" height="147" alt="Screenshot 2025-09-25 at 10 46 41" src="https://github.com/user-attachments/assets/c0a2cadd-5987-4d65-9726-b0734b74790d" />

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-2289
