### PR TITLE
OPHJOD-2398: Show open to new tab icon in hero cards

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1254,7 +1254,7 @@
     },
     "node_modules/@jod/design-system": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/Opetushallitus/jod-design-system.git#8d58538ca3a8187c8e4eca6d0363c994dd77cb48",
+      "resolved": "git+ssh://git@github.com/Opetushallitus/jod-design-system.git#83a966b2fb5b35a9e94e600d831453f507ba55bc",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ark-ui/react": "^5.18.3",

--- a/src/routes/Home/Home.tsx
+++ b/src/routes/Home/Home.tsx
@@ -61,6 +61,7 @@ const MainCard = () => {
           content={t('home.hero-content')}
           title={t('home.hero-title')}
           buttonLabel={t('home.hero-button-label')}
+          buttonIcon={<JodOpenInNew />}
           to={t('home.hero-url')}
           LinkComponent={ExternalLink}
         />
@@ -73,6 +74,7 @@ const SecondaryCard = ({
   title,
   content,
   color,
+  buttonIcon,
   buttonLabel,
   to,
   bgImageClassName,
@@ -80,6 +82,7 @@ const SecondaryCard = ({
   title: string;
   content: string;
   color: string;
+  buttonIcon?: JSX.Element;
   buttonLabel: string;
   to: string;
   bgImageClassName: string;
@@ -96,6 +99,7 @@ const SecondaryCard = ({
             to={to}
             LinkComponent={ExternalLink}
             buttonLabel={buttonLabel}
+            buttonIcon={buttonIcon}
           />
         </div>
       </div>
@@ -272,6 +276,7 @@ const Home = () => {
         title={t('home.ohjaaja-title')}
         to={`/ohjaaja/${language}`}
         buttonLabel={t('home.ohjaaja-call-to-action')}
+        buttonIcon={<JodOpenInNew />}
         bgImageClassName=" bg-[url(@/../assets/ohjaaja.jpg)] bg-cover bg-[50%_50%]"
       />
       <SecondaryCard
@@ -279,6 +284,7 @@ const Home = () => {
         content={t('home.tietopalvelu-content')}
         title={t('home.tietopalvelu-title')}
         to={`/tietopalvelu/${language}`}
+        buttonIcon={<JodOpenInNew />}
         buttonLabel={t('home.tietopalvelu-call-to-action')}
         bgImageClassName="bg-[url(@/../assets/tietopalvelu.jpg)] bg-cover bg-[50%_50%]"
       />


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->
Show open to new tab icon in hero cards

Example card from previous:
<img width="702" height="243" alt="Screenshot 2025-10-06 at 10 36 06" src="https://github.com/user-attachments/assets/81845206-439c-4d31-aae3-e05100015726" />


New:
<img width="583" height="245" alt="Screenshot 2025-10-06 at 10 35 59" src="https://github.com/user-attachments/assets/d26eb02d-bf68-4b73-8cca-844a4be7e55a" />

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-
