### PR TITLE
OPHJOD-3309: Fix HomeAccordion layout in mobile

### DIFF
--- a/src/routes/Home/Home.tsx
+++ b/src/routes/Home/Home.tsx
@@ -157,12 +157,13 @@ const HomeAccordion = ({ title, content, icon, isOpen, setIsOpen }: HomeAccordio
         setIsOpen={setIsOpen}
         title={
           <div className="flex items-center gap-4">
-            <div className="flex size-7 items-center justify-center rounded-full bg-secondary-gray text-white">
+            <div className="flex size-7 shrink-0 items-center justify-center rounded-full bg-secondary-gray text-white">
               {icon}
             </div>
             {title}
           </div>
         }
+        ellipsis={false}
         className="w-full"
       >
         <section id={contentId} className="mt-3 mb-6 ml-[44px] font-arial text-body-md-mobile sm:text-body-md">


### PR DESCRIPTION
<!--
PR checklist for developers:
- Have you ran tests and they pass?
- Did builds complete successfully?
- Remembered to run linters?

a11y:
- Sufficient color contrast for text and UI elements (https://webaim.org/resources/contrastchecker/)
- All interactive elements are accessible via keyboard navigation
- All images and icons have appropriate alt-text or aria-labels
- Headings are used in a logical order (h1, h2, h3...)
- Forms have associated labels and clear error messages
- No keyboard traps (user can navigate away from all elements)
- Focus indicators are visible for interactive elements
- Dynamic content updates are announced to assistive technologies
- Check the console for AXE linter issues
-->

## Description
- Fix HomeAccordion layout in mobile
<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-3309
