### PR TITLE
OPHJOD-3334: Add cookie consent auto-open logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@hookform/error-message": "2.0.1",
         "@hookform/resolvers": "5.2.2",
-        "@jod/design-system": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260415-1/jod-design-system-0.0.0.tgz",
+        "@jod/design-system": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260417-3/jod-design-system-0.0.0.tgz",
         "i18next": "25.8.10",
         "i18next-http-backend": "3.0.2",
         "react": "19.2.4",
@@ -795,8 +795,8 @@
     },
     "node_modules/@jod/design-system": {
       "version": "0.0.0",
-      "resolved": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260415-1/jod-design-system-0.0.0.tgz",
-      "integrity": "sha512-APs4wPItvilezaIlsYdMvukhhoXmgzq6tvYk6ZEYI4Ou0R8CbOalyeD7t44kmjnUFKUaBoJf3zvpsmLTfiD70w==",
+      "resolved": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260417-3/jod-design-system-0.0.0.tgz",
+      "integrity": "sha512-ODUYxg60E2qPU/EOJzymlCdmwDe6fcaFhKBZJ9qLKZEANEkbXlApPvyipudbpZgSf5p13SkARHMfwt21oLxKlw==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ark-ui/react": "5.30.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@hookform/error-message": "2.0.1",
     "@hookform/resolvers": "5.2.2",
-    "@jod/design-system": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260415-1/jod-design-system-0.0.0.tgz",
+    "@jod/design-system": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260417-3/jod-design-system-0.0.0.tgz",
     "i18next": "25.8.10",
     "i18next-http-backend": "3.0.2",
     "react": "19.2.4",

--- a/src/routes/Root/Root.tsx
+++ b/src/routes/Root/Root.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link, Outlet, ScrollRestoration, useLocation } from 'react-router';
+import { Link, Outlet, ScrollRestoration, useHref, useLocation } from 'react-router';
 
 import {
   Button,
@@ -24,6 +24,28 @@ import { useLocalizedRoutes } from '@/hooks/useLocalizedRoutes';
 import { langLabels, supportedLanguageCodes, type LangCode } from '@/i18n/config';
 import { getNotifications } from '@/utils/notifications';
 import { getLinkTo } from '@/utils/routeUtils';
+
+const LanguageButtonWrapper = () => {
+  const {
+    i18n: { language },
+  } = useTranslation();
+  const { generateLocalizedPath } = useLocalizedRoutes();
+  return (
+    <LanguageButton
+      serviceVariant="palveluportaali"
+      testId="language-button"
+      language={language as LangCode}
+      supportedLanguageCodes={supportedLanguageCodes}
+      generateLocalizedPath={generateLocalizedPath}
+      linkComponent={Link}
+      translations={{
+        fi: { change: 'Vaihda kieli.', label: langLabels.fi },
+        sv: { change: 'Andra språk.', label: langLabels.sv },
+        en: { change: 'Change language.', label: langLabels.en },
+      }}
+    />
+  );
+};
 
 const Root = () => {
   const {
@@ -88,8 +110,6 @@ const Root = () => {
     document.documentElement.setAttribute('lang', language);
   }, [language]);
 
-  const { generateLocalizedPath } = useLocalizedRoutes();
-
   React.useEffect(() => {
     getNotifications().forEach((notification) => {
       addTemporaryNote(() => ({
@@ -123,21 +143,7 @@ const Root = () => {
         <NavigationBar
           logo={{ to: `/${language}`, language, srText: t('common:osaamispolku') }}
           menuComponent={<MenuButton onClick={() => setNavMenuOpen(!navMenuOpen)} label={t('common:menu')} />}
-          languageButtonComponent={
-            <LanguageButton
-              serviceVariant="palveluportaali"
-              testId="language-button"
-              language={language as LangCode}
-              supportedLanguageCodes={supportedLanguageCodes}
-              generateLocalizedPath={generateLocalizedPath}
-              linkComponent={Link}
-              translations={{
-                fi: { change: 'Vaihda kieli.', label: langLabels.fi },
-                sv: { change: 'Andra språk.', label: langLabels.sv },
-                en: { change: 'Change language.', label: langLabels.en },
-              }}
-            />
-          }
+          languageButtonComponent={<LanguageButtonWrapper />}
           renderLink={({ to, className, children }) => (
             <Link to={to} className={className}>
               {children as React.ReactNode}
@@ -196,10 +202,13 @@ const Root = () => {
 
 const RootWithCookieConsentProvider = () => {
   const { t } = useTranslation();
+  const { pathname } = useLocation();
+  const href = useHref(t('common:slugs.privacy-and-cookies'));
 
   return (
     <CookieConsentProvider
-      serviceVariant="palveluportaali"
+      automaticallyOpen={pathname !== href}
+      languageButtonComponent={<LanguageButtonWrapper />}
       translations={{
         guard: {
           buttonLabel: t('common:cookie-consent.guard.buttonLabel'),
@@ -214,10 +223,10 @@ const RootWithCookieConsentProvider = () => {
           currentSelectionLabel: t('common:cookie-consent.modal.currentSelectionLabel'),
           declineOptionalLabel: t('common:cookie-consent.modal.declineOptionalLabel'),
           description: t('common:cookie-consent.modal.description'),
-          hereLabel: t('common:cookie-consent.modal.hereLabel'),
           name: t('common:cookie-consent.modal.name'),
           readMoreHref: t('common:cookie-consent.modal.readMoreHref'),
           readMoreLabel: t('common:cookie-consent.modal.readMoreLabel'),
+          externalLinkIconAriaLabel: t('common:external-link'),
           statisticsDescription: t('common:cookie-consent.modal.statisticsDescription'),
           title: t('common:cookie-consent.modal.title'),
         },


### PR DESCRIPTION
<!--
PR checklist for developers:
- Have you ran tests and they pass?
- Did builds complete successfully?
- Remembered to run linters?

a11y:
- Sufficient color contrast for text and UI elements (https://webaim.org/resources/contrastchecker/)
- All interactive elements are accessible via keyboard navigation
- All images and icons have appropriate alt-text or aria-labels
- Headings are used in a logical order (h1, h2, h3...)
- Forms have associated labels and clear error messages
- No keyboard traps (user can navigate away from all elements)
- Focus indicators are visible for interactive elements
- Dynamic content updates are announced to assistive technologies
- Check the console for AXE linter issues
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->
- Add cookie consent auto-open logic
- https://github.com/Opetushallitus/jod-design-system/pull/559
## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-3334
