### PR TITLE
OPHJOD-2972: Fix heading tags on home

### DIFF
--- a/src/routes/Home/Home.tsx
+++ b/src/routes/Home/Home.tsx
@@ -314,8 +314,8 @@ const Home = () => {
           <p>{t('home.competency-path-help.you.text-2')}</p>
         </div>
         <div className="mt-6 flex flex-col gap-7 font-arial text-body-md-mobile sm:flex-row sm:flex-wrap sm:text-body-md">
-          <div className="flex flex-col gap-5 md:max-w-[320px]">
-            <div className="flex h-[70px] flex-col items-start justify-center">{opintopolkuLogo}</div>
+          <div className="md:max-w-xs flex flex-col gap-5">
+            <h3 className="flex h-[70px] flex-col items-start justify-center">{opintopolkuLogo}</h3>
             <div>
               <Trans
                 i18nKey="home.competency-path-help.opintopolku.text-1"
@@ -333,8 +333,8 @@ const Home = () => {
               />
             </div>
           </div>
-          <div className="flex flex-col gap-5 md:max-w-[320px]">
-            <div className="flex h-[70px] flex-col items-start justify-center">{tmtLogo}</div>
+          <div className="md:max-w-xs flex flex-col gap-5">
+            <h3 className="flex h-[70px] flex-col items-start justify-center">{tmtLogo}</h3>
             <div>
               <Trans
                 i18nKey="home.competency-path-help.tyomarkkinatori.text-1"
@@ -352,13 +352,13 @@ const Home = () => {
               />
             </div>
           </div>
-          <div className="flex flex-col gap-5 md:max-w-[320px]">
-            <div className="flex h-[70px] flex-col items-start justify-center">
+          <div className="md:max-w-xs flex flex-col gap-5">
+            <h3 className="flex h-[70px] flex-col items-start justify-center">
               <LogoOpinfi
                 aria-label={t('home.how-competency-path-helps-you-opinfi-title')}
                 className="h-6 max-w-full"
               />
-            </div>
+            </h3>
             <div>
               <Trans
                 i18nKey="home.competency-path-help.opinfi.text-1"


### PR DESCRIPTION
<!--
PR checklist for developers:
- Have you ran tests and they pass?
- Did builds complete successfully?
- Remembered to run linters?

a11y:
- Sufficient color contrast for text and UI elements (https://webaim.org/resources/contrastchecker/)
- All interactive elements are accessible via keyboard navigation
- All images and icons have appropriate alt-text or aria-labels
- Headings are used in a logical order (h1, h2, h3...)
- Forms have associated labels and clear error messages
- No keyboard traps (user can navigate away from all elements)
- Focus indicators are visible for interactive elements
- Dynamic content updates are announced to assistive technologies
- Check the console for AXE linter issues
-->

## Description
- Fix heading tags on home
<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-2972
