### PR TITLE
OPHJOD-3121: Update PortalLink to not be external link

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@hookform/error-message": "2.0.1",
         "@hookform/resolvers": "5.2.2",
-        "@jod/design-system": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260421-2/jod-design-system-0.0.0.tgz",
+        "@jod/design-system": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260423-2/jod-design-system-0.0.0.tgz",
         "i18next": "25.8.10",
         "i18next-http-backend": "3.0.2",
         "react": "19.2.4",
@@ -795,8 +795,8 @@
     },
     "node_modules/@jod/design-system": {
       "version": "0.0.0",
-      "resolved": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260421-2/jod-design-system-0.0.0.tgz",
-      "integrity": "sha512-wB2a4a+arBUKy8jMxgT3I0RJuQJOZ9Bvm0u+xnzjZpVMwUCqj4zE8c9eT3WTZvIJFH61yHRsRHamNAwjy/SbJw==",
+      "resolved": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260423-2/jod-design-system-0.0.0.tgz",
+      "integrity": "sha512-5uAqjo3EzKn8xruTLd7+NknT99RBFJBJiQodWRoMZy676H/zd9ubS9o9tYZgSgj47bXiGgaBhmvmpL0f0P6bKA==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ark-ui/react": "5.30.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@hookform/error-message": "2.0.1",
     "@hookform/resolvers": "5.2.2",
-    "@jod/design-system": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260421-2/jod-design-system-0.0.0.tgz",
+    "@jod/design-system": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260423-2/jod-design-system-0.0.0.tgz",
     "i18next": "25.8.10",
     "i18next-http-backend": "3.0.2",
     "react": "19.2.4",

--- a/src/components/NavMenu/NavMenu.tsx
+++ b/src/components/NavMenu/NavMenu.tsx
@@ -98,6 +98,7 @@ export const NavMenu = ({ open, onClose }: { open: boolean; onClose: () => void 
       openSubMenuLabel={t('common:open-submenu')}
       portalLinkComponent={PortalLink}
       portalLinkLabel={t('common:competency-path-portal')}
+      portalExternal={false}
       selectedLanguage={language}
       serviceVariant="palveluportaali"
       externalLinkIconAriaLabel={t('common:external-link')}


### PR DESCRIPTION

<!--
PR checklist for developers:
- Have you ran tests and they pass?
- Did builds complete successfully?
- Remembered to run linters?

a11y:
- Sufficient color contrast for text and UI elements (https://webaim.org/resources/contrastchecker/)
- All interactive elements are accessible via keyboard navigation
- All images and icons have appropriate alt-text or aria-labels
- Headings are used in a logical order (h1, h2, h3...)
- Forms have associated labels and clear error messages
- No keyboard traps (user can navigate away from all elements)
- Focus indicators are visible for interactive elements
- Dynamic content updates are announced to assistive technologies
- Check the console for AXE linter issues
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

- Update `@jod/design-system`
- Update portallink to not be external
  - Landing page == portal page


## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-3121
