### PR TITLE
OPHJOD-2183: Change feedback toast to modal

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -21,5 +21,6 @@ export default defineConfig({
         ignoreRestSiblings: true,
       },
     ],
+    'vitest/require-mock-type-parameters': 'off',
   },
 });

--- a/src/components/ConfirmDialogWrapper/ConfirmDialogWrapper.tsx
+++ b/src/components/ConfirmDialogWrapper/ConfirmDialogWrapper.tsx
@@ -1,0 +1,136 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Button, ConfirmDialog, Spinner, useMediaQueries } from '@jod/design-system';
+
+import { useModal } from '@/hooks/useModal';
+
+const isPromise = (func: (() => Promise<void>) | (() => void)) => {
+  return func.constructor.name === 'AsyncFunction' || func instanceof Promise;
+};
+
+type ConfirmDialogProps = React.ComponentProps<typeof ConfirmDialog>;
+type MaybePromise<T> = T | Promise<T>;
+
+export type ConfirmDialogWrapperProps = Omit<ConfirmDialogProps, 'children' | 'content'> & {
+  /** Closes parent modals on confirmation */
+  closeParentModal?: boolean;
+  /** Content component for the ConfirmationDialog */
+  content?: React.ReactNode | (() => React.ReactNode);
+  /** onConfirm handler. If it's a promise/async function, it will be awaited and a loading spinner will be shown in the confirm button */
+  onConfirm?: () => MaybePromise<void>;
+  /** Whether to hide the secondary (cancel) button */
+  hideSecondaryButton?: boolean;
+  /** Callback for when the cancel button is clicked */
+  onCancel?: () => void;
+  /** Icon for the confirm button */
+  confirmButtonIcon?: React.ReactNode;
+};
+
+/**
+ * An internal component to use as the "children" prop of the DS ConfirmDialog.
+ * It will just call the "showDialog" function passed to it when the component mounts.
+ */
+const ShowDialogWrapper = (showDialog: () => void) => {
+  React.useEffect(() => {
+    showDialog();
+    // Ensure that this effect runs only once when the component mounts.
+    // oxlint-disable-next-line eslint-plugin-react-hooks/exhaustive-deps
+  }, []);
+  return <></>;
+};
+
+/**
+ * A wrapper around the DS ConfirmDialog that allows it to be used with the "useModal" hook.
+ */
+export const ConfirmDialogWrapper = ({
+  title,
+  description,
+  cancelText,
+  confirmText,
+  variant = 'destructive',
+  hideSecondaryButton,
+  closeParentModal,
+  confirmButtonIcon,
+  animationMode,
+  shouldRenderBackdrop,
+  onConfirm,
+  onCancel,
+  footer,
+  content,
+}: ConfirmDialogWrapperProps) => {
+  const { closeActiveModal, closeAllModals } = useModal();
+  const { t } = useTranslation();
+  const { sm } = useMediaQueries();
+  const defaultCancelText = t('common:cancel');
+  const defaultConfirmText = title as string;
+  const [loading, setLoading] = React.useState(false);
+
+  const DefaultFooter = (hideDialog: () => void) => (
+    <>
+      {!hideSecondaryButton && (
+        <Button
+          label={cancelText ?? defaultCancelText}
+          size={sm ? 'lg' : 'sm'}
+          className="not-sm:h-5"
+          onClick={() => {
+            if (loading) {
+              return;
+            }
+            onCancel?.();
+            hideDialog();
+            closeActiveModal();
+          }}
+        />
+      )}
+      <Button
+        label={confirmText ?? defaultConfirmText}
+        iconSide="right"
+        icon={loading ? <Spinner size={24} color="white" /> : confirmButtonIcon}
+        size={sm ? 'lg' : 'sm'}
+        className="not-sm:h-5"
+        onClick={async () => {
+          if (loading) {
+            return;
+          }
+
+          if (onConfirm) {
+            if (isPromise(onConfirm)) {
+              const fn = onConfirm as () => Promise<void>;
+              setLoading(true);
+              await fn();
+            } else {
+              onConfirm();
+            }
+          }
+
+          setLoading(false);
+          hideDialog();
+          // There aren't any places in the UI where there's more than 2 modals open at the same time,
+          // so we can safely close all modals when closeParentModal is true.
+          // Most likely scenario for closing all modals is when the user deletes an entity from it's edit modal.
+          if (closeParentModal) {
+            closeAllModals();
+          } else {
+            closeActiveModal();
+          }
+        }}
+        variant={variant === 'destructive' ? 'red-delete' : 'accent'}
+        serviceVariant="ohjaaja"
+      />
+    </>
+  );
+
+  return (
+    <ConfirmDialog
+      title={title}
+      description={description}
+      content={typeof content === 'function' ? content() : content}
+      footer={footer ?? DefaultFooter}
+      animationMode={animationMode}
+      shouldRenderBackdrop={shouldRenderBackdrop}
+    >
+      {ShowDialogWrapper}
+    </ConfirmDialog>
+  );
+};

--- a/src/components/FeedbackModal/FeedbackModal.tsx
+++ b/src/components/FeedbackModal/FeedbackModal.tsx
@@ -5,8 +5,19 @@ import toast from 'react-hot-toast/headless';
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
 
-import { Button, Checkbox, InputField, Modal, RadioButton, RadioButtonGroup, Textarea } from '@jod/design-system';
+import {
+  Button,
+  Checkbox,
+  InputField,
+  Modal,
+  RadioButton,
+  RadioButtonGroup,
+  Textarea,
+  useMediaQueries,
+} from '@jod/design-system';
 import { JodOpenInNew } from '@jod/design-system/icons';
+
+import { useModal } from '@/hooks/useModal/useModal';
 
 const DETAILS_MAX_LENGTH = 2048;
 const MESSAGE_MAX_LENGTH = 5000;
@@ -46,6 +57,28 @@ const Feedback = z
 
 type Feedback = z.infer<typeof Feedback>;
 
+const FeedbackSuccessFooter = ({
+  hideDialog,
+  closeActiveModal,
+  label,
+  size,
+}: {
+  hideDialog: () => void;
+  closeActiveModal: () => void;
+  label: string;
+  size: 'lg' | 'sm';
+}) => (
+  <Button
+    label={label}
+    size={size}
+    variant="accent"
+    onClick={() => {
+      hideDialog();
+      closeActiveModal();
+    }}
+  />
+);
+
 export interface FeedbackModalProps {
   isOpen: boolean;
   onClose: () => void;
@@ -72,6 +105,20 @@ export const FeedbackModal = ({ isOpen, onClose, section, area, language }: Feed
   const { isValid, errors } = useFormState({ control });
   const wantsContact = watch('wantsContact');
   const [isSubmitting, setIsSubmitting] = React.useState(false);
+  const { showDialog, closeActiveModal } = useModal();
+  const { sm } = useMediaQueries();
+
+  const successFooter = React.useCallback(
+    (hideDialog: () => void) => (
+      <FeedbackSuccessFooter
+        hideDialog={hideDialog}
+        closeActiveModal={closeActiveModal}
+        label={t('common:feedback.close')}
+        size={sm ? 'lg' : 'sm'}
+      />
+    ),
+    [closeActiveModal, t, sm],
+  );
 
   React.useEffect(() => {
     reset();
@@ -109,9 +156,11 @@ export const FeedbackModal = ({ isOpen, onClose, section, area, language }: Feed
       reset();
       onClose();
 
-      // Wait a moment before showing success message
-      await new Promise((resolve) => setTimeout(resolve, 50));
-      toast.success(t('common:feedback.success'));
+      showDialog({
+        title: t('common:feedback.success-title'),
+        description: t('common:feedback.success-description'),
+        footer: successFooter,
+      });
     } catch (_) {
       setIsSubmitting(false);
       toast.error(t('common:feedback.error'));

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,3 +1,4 @@
 export { FeedbackModal } from './FeedbackModal/FeedbackModal';
 export { MainLayout } from './MainLayout/MainLayout';
 export { UserButton } from './UserButton/UserButton';
+export { ConfirmDialogWrapper, type ConfirmDialogWrapperProps } from './ConfirmDialogWrapper/ConfirmDialogWrapper';

--- a/src/hooks/useModal/ModalContext.ts
+++ b/src/hooks/useModal/ModalContext.ts
@@ -1,0 +1,5 @@
+import React from 'react';
+
+import type { ModalContextType } from '@/hooks/useModal/utils';
+
+export const ModalContext = React.createContext<ModalContextType | undefined>(undefined);

--- a/src/hooks/useModal/ModalProvider.test.tsx
+++ b/src/hooks/useModal/ModalProvider.test.tsx
@@ -1,0 +1,104 @@
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useModal } from '@/hooks/useModal';
+
+import { ModalProvider } from './ModalProvider';
+
+const TestModal = vi.fn(({ isOpen, onClose, label }) => {
+  if (!isOpen) return null;
+  return (
+    <div data-testid="test-modal">
+      <span>{label}</span>
+      <button onClick={onClose}>Close</button>
+    </div>
+  );
+});
+
+describe('ModalProvider', () => {
+  it('renders nothing when no modal is open', () => {
+    render(
+      <ModalProvider>
+        <div>Child</div>
+      </ModalProvider>,
+    );
+    expect(screen.queryByTestId('test-modal')).toBeNull();
+  });
+
+  it('renders modalToRender when showModal is called', () => {
+    const Consumer = () => {
+      const { showModal } = useModal();
+      return <button onClick={() => showModal(TestModal, { label: 'Hello' })}>Open Modal</button>;
+    };
+    render(
+      <ModalProvider>
+        <Consumer />
+      </ModalProvider>,
+    );
+    fireEvent.click(screen.getByText('Open Modal'));
+    expect(screen.getByTestId('test-modal')).toBeInTheDocument();
+    expect(screen.getByText('Hello')).toBeInTheDocument();
+  });
+
+  it('passes isOpen=true and onClose to modal', () => {
+    const Consumer = () => {
+      const { showModal } = useModal();
+      return <button onClick={() => showModal(TestModal, { label: 'Test' })}>Open Modal</button>;
+    };
+    render(
+      <ModalProvider>
+        <Consumer />
+      </ModalProvider>,
+    );
+    fireEvent.click(screen.getByText('Open Modal'));
+    expect(TestModal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isOpen: true,
+        label: 'Test',
+        onClose: expect.any(Function),
+      }),
+      undefined,
+    );
+  });
+
+  it('removes modal when onClose is called', () => {
+    const Consumer = () => {
+      const { showModal } = useModal();
+      return <button onClick={() => showModal(TestModal, { label: 'Bye' })}>Open Modal</button>;
+    };
+    render(
+      <ModalProvider>
+        <Consumer />
+      </ModalProvider>,
+    );
+    fireEvent.click(screen.getByText('Open Modal'));
+    const closeBtn = screen.getByText('Close');
+    fireEvent.click(closeBtn);
+    expect(screen.queryByTestId('test-modal')).toBeNull();
+  });
+
+  it('renders only the top modal when multiple are stacked', () => {
+    const Consumer = () => {
+      const { showModal } = useModal();
+      return (
+        <>
+          <button onClick={() => showModal(TestModal, { label: 'First' })}>Open First</button>
+          <button onClick={() => showModal(TestModal, { label: 'Second' })}>Open Second</button>
+        </>
+      );
+    };
+    render(
+      <ModalProvider>
+        <Consumer />
+      </ModalProvider>,
+    );
+    fireEvent.click(screen.getByText('Open First'));
+    fireEvent.click(screen.getByText('Open Second'));
+    expect(screen.getByText('Second')).toBeInTheDocument();
+    expect(screen.queryByText('First')).toBeNull();
+    // Close top modal
+    fireEvent.click(screen.getByText('Close'));
+    expect(screen.getByText('First')).toBeInTheDocument();
+  });
+});

--- a/src/hooks/useModal/ModalProvider.tsx
+++ b/src/hooks/useModal/ModalProvider.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+
+import { ConfirmDialogWrapper, type ConfirmDialogWrapperProps } from '@/components';
+
+import { ModalContext } from './ModalContext';
+import type { ModalComponentType, ModalStackItem } from './utils';
+
+export const ModalProvider = ({ children }: { children: React.ReactNode }) => {
+  const [modals, setModals] = React.useState<ModalStackItem<any>[]>([]);
+
+  const showModal = React.useCallback(
+    <P extends object>(Component: ModalComponentType<P>, props?: Omit<Partial<P>, 'isOpen'>) => {
+      setModals((prev) => {
+        const last = prev.at(-1);
+        // Prevent duplicate: compare Component and shallow props
+        const isDuplicate = last?.Component === Component && JSON.stringify(last.props) === JSON.stringify(props);
+        if (isDuplicate) {
+          return prev;
+        }
+        return [
+          ...prev,
+          {
+            Component,
+            props,
+          },
+        ];
+      });
+    },
+    [],
+  );
+
+  const closeActiveModal = React.useCallback(() => {
+    if (modals.length === 0) {
+      return;
+    }
+    setModals((prev) => prev.slice(0, -1));
+  }, [modals]);
+
+  const closeAllModals = React.useCallback(() => {
+    setModals([]);
+  }, []);
+
+  const showDialog = React.useCallback(
+    (props: ConfirmDialogWrapperProps) => {
+      showModal(ConfirmDialogWrapper, props);
+    },
+    [showModal],
+  );
+
+  const memoizedContextValue = React.useMemo(
+    () => ({
+      showModal,
+      closeActiveModal,
+      closeAllModals,
+      showDialog,
+    }),
+    [showModal, closeActiveModal, closeAllModals, showDialog],
+  );
+
+  return (
+    <ModalContext.Provider value={memoizedContextValue}>
+      {children}
+      {modals.map((modal, idx) => {
+        const ModalComponent = modal.Component;
+        // Only the top modal is open/interactable
+        const isActive = idx === modals.length - 1;
+        const handleClose = () => {
+          modal.props?.onClose?.();
+          closeActiveModal();
+        };
+        return (
+          <ModalComponent
+            key={modal.Component.displayName ?? `${idx}`}
+            {...modal.props}
+            isOpen={isActive}
+            onClose={handleClose}
+            style={{ zIndex: 1000 + idx }}
+          />
+        );
+      })}
+    </ModalContext.Provider>
+  );
+};

--- a/src/hooks/useModal/index.ts
+++ b/src/hooks/useModal/index.ts
@@ -1,0 +1,4 @@
+export { ModalContext } from './ModalContext';
+export { ModalProvider } from './ModalProvider';
+export { useModal } from './useModal';
+export type { ModalComponentProps, ModalComponentType, ModalContextType, ModalStackItem } from './utils';

--- a/src/hooks/useModal/useModal.ts
+++ b/src/hooks/useModal/useModal.ts
@@ -1,0 +1,11 @@
+import React from 'react';
+
+import { ModalContext } from './ModalContext';
+
+export const useModal = () => {
+  const context = React.useContext(ModalContext);
+  if (!context) {
+    throw new Error('useModal must be used within a ModalProvider');
+  }
+  return context;
+};

--- a/src/hooks/useModal/utils.ts
+++ b/src/hooks/useModal/utils.ts
@@ -1,0 +1,26 @@
+import React from 'react';
+
+import { ConfirmDialogWrapperProps } from '@/components';
+
+export interface ModalComponentProps {
+  onClose: () => void;
+  isOpen: boolean;
+}
+
+export type ModalComponentType<P = ModalComponentProps> = React.ComponentType<P>;
+
+export interface ModalStackItem<P> {
+  Component: ModalComponentType<P>;
+  props: P;
+}
+
+export interface ModalContextType {
+  /** Puts a DS modal at the top of the modal stack. Only topmost modal is visible. */
+  showModal: <P extends object>(modal: ModalComponentType<P>, props?: Omit<Partial<P>, 'isOpen'>) => void;
+  /** Puts a DS confirm dialog at the top of the modal stack. Only topmost modal is visible. */
+  showDialog: (props: ConfirmDialogWrapperProps) => void;
+  /** Closes the topmost modal in the stack. */
+  closeActiveModal: () => void;
+  /** Closes all modals in the stack. */
+  closeAllModals: () => void;
+}

--- a/src/i18n/common/en.json
+++ b/src/i18n/common/en.json
@@ -40,6 +40,7 @@
   "external-link": "The link leads outside the service",
   "feedback": {
     "cancel": "Cancel",
+    "close": "Close",
     "email-label": "E-mail address",
     "error": "Failed to send feedback. Please try again later.",
     "footer-handled": {
@@ -73,6 +74,8 @@
     },
     "submit": "Submit",
     "success": "Thank you for your feedback! Your feedback will help us to improve the service.",
+    "success-description": "Your feedback helps us improve the service.",
+    "success-title": "Thank you for your feedback!",
     "title": "Give feedback",
     "type-question": "What kind of feedback would you like to give?",
     "types": {
@@ -161,6 +164,13 @@
   "required": "mandatory",
   "return-home": "Return to the front page",
   "session": {
+    "auth-error": {
+      "description": "Login failed. Please try again.",
+      "reason": {
+        "method-not-allowed": "The login method you selected is not allowed."
+      },
+      "title": "Login failed"
+    },
     "expired": {
       "continue": "Continue without logging in",
       "login": "Log in again",

--- a/src/i18n/common/fi.json
+++ b/src/i18n/common/fi.json
@@ -40,6 +40,7 @@
   "external-link": "Linkki johtaa palvelun ulkopuolelle",
   "feedback": {
     "cancel": "Peruuta",
+    "close": "Sulje",
     "email-label": "Sähköpostiosoite",
     "error": "Palautteen lähettäminen epäonnistui. Yritä myöhemmin uudelleen.",
     "footer-handled": {
@@ -73,6 +74,8 @@
     },
     "submit": "Lähetä",
     "success": "Kiitos palautteestasi! Palautteesi auttaa meitä parantamaan palvelua.",
+    "success-description": "Palautteesi auttaa meitä parantamaan palvelua.",
+    "success-title": "Kiitos palautteestasi!",
     "title": "Anna palautetta",
     "type-question": "Minkälaista palautetta haluat antaa?",
     "types": {
@@ -160,6 +163,13 @@
   "required": "pakollinen",
   "return-home": "Palaa etusivulle",
   "session": {
+    "auth-error": {
+      "description": "Kirjautuminen ei onnistunut. Yritä uudelleen.",
+      "reason": {
+        "method-not-allowed": "Valitsemasi kirjautumistapa ei ole sallittu."
+      },
+      "title": "Kirjautuminen epäonnistui"
+    },
     "expired": {
       "continue": "Jatka kirjautumatta",
       "login": "Kirjaudu uudelleen",

--- a/src/i18n/common/sv.json
+++ b/src/i18n/common/sv.json
@@ -40,6 +40,7 @@
   "external-link": "Länken leder dig utanför tjänsten",
   "feedback": {
     "cancel": "Avbryt",
+    "close": "Stäng",
     "email-label": "E-postadress",
     "error": "Det gick inte att skicka respons. Försök på nytt senare.",
     "footer-handled": {
@@ -73,6 +74,8 @@
     },
     "submit": "Skicka",
     "success": "Tack för din respons! Din respons hjälper oss att förbättra tjänsten.",
+    "success-description": "Din feedback hjälper oss att förbättra tjänsten.",
+    "success-title": "Tack för din respons!",
     "title": "Ge respons",
     "type-question": "Vilken typ av respons vill du ge?",
     "types": {
@@ -160,6 +163,13 @@
   "required": "obligatorisk",
   "return-home": "Återgå till förstasidan",
   "session": {
+    "auth-error": {
+      "description": "Inloggningen misslyckades. Försök igen.",
+      "reason": {
+        "method-not-allowed": "Den inloggningsmetod du valde är inte tillåten."
+      },
+      "title": "Inloggningen misslyckades"
+    },
     "expired": {
       "continue": "Fortsätt utan att logga in",
       "login": "Logga in igen",

--- a/src/i18n/landing-page/en.json
+++ b/src/i18n/landing-page/en.json
@@ -628,7 +628,7 @@
         "title": "Contact person:"
       },
       "email": {
-        "content": "tietosuoja@oph.fi or tietosuoja.keha@ely-keskus.fi",
+        "content": "tietosuoja@oph.fi or tietosuoja@keha-keskus.fi ",
         "title": "Email:"
       },
       "fax": {

--- a/src/i18n/landing-page/fi.json
+++ b/src/i18n/landing-page/fi.json
@@ -628,7 +628,7 @@
         "title": "Yhteyshenkilö:"
       },
       "email": {
-        "content": "tietosuoja@oph.fi tai tietosuoja.keha@ely-keskus.fi",
+        "content": "tietosuoja@oph.fi tai tietosuoja@keha-keskus.fi ",
         "title": "Sähköposti:"
       },
       "fax": {

--- a/src/i18n/landing-page/sv.json
+++ b/src/i18n/landing-page/sv.json
@@ -628,7 +628,7 @@
         "title": "Kontaktperson:"
       },
       "email": {
-        "content": "tietosuoja@oph.fi eller tietosuoja.keha@ely-keskus.fi",
+        "content": "tietosuoja@oph.fi eller tietosuoja@keha-keskus.fi ",
         "title": "E-post:"
       },
       "fax": {

--- a/src/routes/Root/Root.tsx
+++ b/src/routes/Root/Root.tsx
@@ -21,6 +21,7 @@ import { FeedbackModal } from '@/components';
 import { NavMenu } from '@/components/NavMenu/NavMenu';
 import { Toaster } from '@/components/Toaster/Toaster';
 import { useLocalizedRoutes } from '@/hooks/useLocalizedRoutes';
+import { ModalProvider } from '@/hooks/useModal/ModalProvider';
 import { langLabels, supportedLanguageCodes, type LangCode } from '@/i18n/config';
 import { getNotifications } from '@/utils/notifications';
 import { getLinkTo } from '@/utils/routeUtils';
@@ -233,7 +234,9 @@ const RootWithCookieConsentProvider = () => {
         },
       }}
     >
-      <Root />
+      <ModalProvider>
+        <Root />
+      </ModalProvider>
     </CookieConsentProvider>
   );
 };

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -2,6 +2,7 @@ import { RouteObject, replace } from 'react-router';
 
 import { NoteStackProvider } from '@jod/design-system';
 
+import { ModalProvider } from '@/hooks/useModal/ModalProvider';
 import i18n, { supportedLanguageCodes } from '@/i18n/config';
 
 import { AboutService, AiUsage, DataSources, PrivacyAndCookies } from './BasicInformation';
@@ -93,7 +94,9 @@ const rootRoute: RouteObject = {
   loader: loader,
   element: (
     <NoteStackProvider>
-      <Root />
+      <ModalProvider>
+        <Root />
+      </ModalProvider>
     </NoteStackProvider>
   ),
   children: [

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -22,5 +22,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["vite.config.ts", "vitest.setup.ts", "extractor.ts"]
+  "include": ["vite.config.ts", "extractor.ts"]
 }

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,1 +1,16 @@
 import '@testing-library/jest-dom/vitest';
+import { vi } from 'vitest';
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});


### PR DESCRIPTION
<!--
PR checklist for developers:
- Have you ran tests and they pass?
- Did builds complete successfully?
- Remembered to run linters?

a11y:
- Sufficient color contrast for text and UI elements (https://webaim.org/resources/contrastchecker/)
- All interactive elements are accessible via keyboard navigation
- All images and icons have appropriate alt-text or aria-labels
- Headings are used in a logical order (h1, h2, h3...)
- Forms have associated labels and clear error messages
- No keyboard traps (user can navigate away from all elements)
- Focus indicators are visible for interactive elements
- Dynamic content updates are announced to assistive technologies
- Check the console for AXE linter issues
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->
- Change feedback toast to modal
## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-2183
