### PR TITLE
OPHJOD-2133: Update color tokens usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@hookform/error-message": "2.0.1",
         "@hookform/resolvers": "5.4.0",
-        "@jod/design-system": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260608-2/jod-design-system-0.0.0.tgz",
+        "@jod/design-system": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260612-1/jod-design-system-0.0.0.tgz",
         "i18next": "26.2.0",
         "i18next-http-backend": "4.0.0",
         "react": "19.2.6",
@@ -814,8 +814,8 @@
     },
     "node_modules/@jod/design-system": {
       "version": "0.0.0",
-      "resolved": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260608-2/jod-design-system-0.0.0.tgz",
-      "integrity": "sha512-cetrI/nJusi4GI5mo7OGmywa3wXBOLFltPIA4vFUqSrdhmqBJAXywAowcHHP4XdKnytE0ozLTKKcaD5MTblKDA==",
+      "resolved": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260612-1/jod-design-system-0.0.0.tgz",
+      "integrity": "sha512-QR5I89D2wvaR9bq5p/HS+1iiOILF6S+Az/7oG77TokT5TVhZSgtVpeDI20QrOoAHca4d1JqepXcfgKuYsixozg==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ark-ui/react": "5.36.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@hookform/error-message": "2.0.1",
     "@hookform/resolvers": "5.4.0",
-    "@jod/design-system": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260608-2/jod-design-system-0.0.0.tgz",
+    "@jod/design-system": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260612-1/jod-design-system-0.0.0.tgz",
     "i18next": "26.2.0",
     "i18next-http-backend": "4.0.0",
     "react": "19.2.6",

--- a/src/components/InfoBox/index.tsx
+++ b/src/components/InfoBox/index.tsx
@@ -19,12 +19,12 @@ export const InfoBox = ({ items, className = '' }: InfoBoxProps) => {
         className,
       )}
     >
-      <JodInfo className="text-secondary-1-dark-2" />
+      <JodInfo className="text-primary-1-dark-2" />
       <div className="flex flex-1 flex-col">
         {items.map((item) => (
           <div key={item.label} className="flex gap-2">
             <span>{item.label}</span>
-            <span className="text-secondary-1-dark-2">{item.content}</span>
+            <span className="text-primary-1-dark-2">{item.content}</span>
           </div>
         ))}
       </div>

--- a/src/components/NavMenu/NavMenu.tsx
+++ b/src/components/NavMenu/NavMenu.tsx
@@ -15,7 +15,7 @@ const PortalLink = ({ children, className }: LinkComponent) => {
   const activeClasses = cx(
     'text-white!',
     'bg-secondary-gray',
-    'hover:bg-secondary-5-light-3!',
+    'hover:bg-primary-5-light-3!',
     'hover:text-primary-gray!',
     'active:bg-primary-gray!',
     'active:text-white!',

--- a/src/components/UserButton/UserButton.tsx
+++ b/src/components/UserButton/UserButton.tsx
@@ -18,7 +18,7 @@ export const UserButton = ({ user }: { user: { name: string; component: JSX.Elem
 
   return user ? (
     <user.component
-      className="flex h-8 w-8 items-center justify-center rounded-full bg-secondary-3 text-primary-gray select-none"
+      className="flex h-8 w-8 items-center justify-center rounded-full bg-primary-3 text-primary-gray select-none"
       role="img"
       title={user.name}
     >

--- a/src/routes/BasicInformation/MyPathImage.tsx
+++ b/src/routes/BasicInformation/MyPathImage.tsx
@@ -391,7 +391,7 @@ const MyPathMobile = () => {
         </div>
       </div>
       <div className="flex flex-col items-center">
-        <div className="flex w-full items-center gap-3 rounded-md bg-secondary-1-light-2 py-3 pr-3 pl-5">
+        <div className="flex w-full items-center gap-3 rounded-md bg-primary-1-light-2 py-3 pr-3 pl-5">
           <span className="grow">{t('about-service.sections.my-path.image.enter-your-info')}</span>
           <svg xmlns="http://www.w3.org/2000/svg" width="42" height="42" viewBox="0 0 42 42" fill="none">
             <path
@@ -416,7 +416,7 @@ const MyPathMobile = () => {
               />
               <path d="M17 4.50011L24.5 8.96083e-07L24.5 24L17 19.5001L17 4.50011Z" fill="white" />
             </svg>
-            <div className="w-[140px] rounded-[30px] border-2 border-secondary-1-dark bg-white p-4">
+            <div className="w-[140px] rounded-[30px] border-2 border-primary-1-dark bg-white p-4">
               {t('about-service.sections.my-path.image.tell-about-skills')}
             </div>
           </div>
@@ -427,25 +427,25 @@ const MyPathMobile = () => {
           <ServiceHelpsWithAiTooltip />
         </div>
         <ArrowMobile color="#B4B5E4" className="mb-2" />
-        <div className="flex w-full items-center justify-between gap-3 rounded-md bg-secondary-1-light-1 px-5 py-3">
+        <div className="flex w-full items-center justify-between gap-3 rounded-md bg-primary-1-light-1 px-5 py-3">
           {t('about-service.sections.my-path.image.choose-interests-and-skills')}
           <ChooseInterestsAndSkillsTooltip />
         </div>
         <ArrowMobile color="#85c4ec" className="mb-2" />
-        <div className="grid w-full grid-cols-2 gap-2 rounded-md border-4 border-secondary-1-light-2 bg-white p-2 text-right text-white">
-          <div className="flex items-center justify-center gap-3 rounded-sm bg-secondary-1-dark p-3">
+        <div className="grid w-full grid-cols-2 gap-2 rounded-md border-4 border-primary-1-light-2 bg-white p-2 text-right text-white">
+          <div className="flex items-center justify-center gap-3 rounded-sm bg-primary-1-dark p-3">
             {t('about-service.sections.my-path.image.professions')}
             <ProfessionsTooltip />
           </div>
-          <div className="flex items-center justify-center gap-3 rounded-sm bg-secondary-1 p-3">
+          <div className="flex items-center justify-center gap-3 rounded-sm bg-primary-1 p-3">
             {t('about-service.sections.my-path.image.degrees')}
             <DegreesTooltip />
           </div>
-          <div className="flex items-center justify-center gap-3 rounded-sm bg-secondary-1-dark p-3">
+          <div className="flex items-center justify-center gap-3 rounded-sm bg-primary-1-dark p-3">
             {t('about-service.sections.my-path.image.other-work-opportunities')}
             <OtherWorkPpportunitiesTooltip />
           </div>
-          <div className="flex items-center justify-center gap-3 rounded-sm bg-secondary-1 p-3">
+          <div className="flex items-center justify-center gap-3 rounded-sm bg-primary-1 p-3">
             {t('about-service.sections.my-path.image.other-education')}
             <OtherEducationTooltip />
           </div>
@@ -458,7 +458,7 @@ const MyPathMobile = () => {
         <div className="grid w-full grid-cols-2 gap-5">
           <div className="flex h-full flex-col items-center">
             <ArrowMobile color="#CCC" rotation={180} className="mt-2" />
-            <div className="flex w-full flex-1 flex-col items-end justify-between gap-3 rounded-md bg-primary-light-2 px-5 py-3">
+            <div className="flex w-full flex-1 flex-col items-end justify-between gap-3 rounded-md bg-primary-5-light-2 px-5 py-3">
               <div className="flex flex-col items-end">
                 <span>{t('about-service.sections.my-path.image.career-info')}</span>
                 <span>{t('about-service.sections.my-path.image.job-postings')}</span>
@@ -468,7 +468,7 @@ const MyPathMobile = () => {
           </div>
           <div className="flex h-full flex-col items-center">
             <ArrowMobile color="#CCC" rotation={180} className="mt-2" />
-            <div className="flex w-full flex-1 flex-col items-end justify-between gap-3 rounded-md bg-primary-light-2 px-5 py-3">
+            <div className="flex w-full flex-1 flex-col items-end justify-between gap-3 rounded-md bg-primary-5-light-2 px-5 py-3">
               {t('about-service.sections.my-path.image.education-options')}
               {opintopolkuLogo}
             </div>

--- a/src/routes/BasicInformation/PrivacyAndCookies.tsx
+++ b/src/routes/BasicInformation/PrivacyAndCookies.tsx
@@ -552,7 +552,7 @@ const PrivacyAndCookies = () => {
             );
           })}
 
-          <hr className="my-8 border-t-2 border-t-border-form" />
+          <hr className="border-t-border-form my-8 border-t-2" />
 
           {cookiesSections.map((section, index) => {
             const navStyle = index === 0 ? 'mb-6' : 'mb-3';

--- a/src/routes/Home/Home.tsx
+++ b/src/routes/Home/Home.tsx
@@ -83,7 +83,7 @@ const MainCard = () => {
       <div className="relative mx-auto max-w-[1092px] px-5 sm:px-6 xl:px-0" ref={firstCardRef}>
         <div className="max-w-[716px]">
           <HeroCard
-            backgroundColor="var(--color-secondary-1-dark-2)"
+            backgroundColor="var(--color-primary-1-dark-2)"
             content={t('home.hero.content')}
             title={t('home.hero.title')}
             titleLevel={1}
@@ -274,7 +274,7 @@ const Home = () => {
       </Content>
       <Content className="grid grid-cols-1 gap-7 lg:grid-cols-3">
         <HeroCard
-          backgroundColor="var(--color-secondary-1-dark-2)"
+          backgroundColor="var(--color-primary-1-dark-2)"
           content={t('home.sections.osaamispolku.content')}
           title={t('home.sections.osaamispolku.title')}
           size="sm"
@@ -286,7 +286,7 @@ const Home = () => {
           buttonIcon={<JodOpenInNew ariaLabel={t('common:external-link')} />}
         />
         <HeroCard
-          backgroundColor="var(--color-secondary-2-dark)"
+          backgroundColor="var(--color-primary-2-dark)"
           content={t('home.sections.ohjaaja.content')}
           title={t('home.sections.ohjaaja.title')}
           size="sm"
@@ -297,7 +297,7 @@ const Home = () => {
           buttonIcon={<JodOpenInNew ariaLabel={t('common:external-link')} />}
         />
         <HeroCard
-          backgroundColor="var(--color-secondary-4-dark)"
+          backgroundColor="var(--color-primary-4-dark)"
           content={t('home.sections.tietopalvelu.content')}
           title={t('home.sections.tietopalvelu.title')}
           to={`/tietopalvelu/${language}`}
@@ -390,7 +390,7 @@ const Home = () => {
             buttonIcon={<JodOpenInNew ariaLabel={t('common:external-link')} />}
             titleLevel={2}
             titleClassName="text-heading-2"
-            backgroundColor="var(--color-secondary-2-dark)"
+            backgroundColor="var(--color-primary-2-dark)"
           />
         </div>
       </Content>


### PR DESCRIPTION
<!--
PR checklist for developers:
- Have you ran tests and they pass?
- Did builds complete successfully?
- Remembered to run linters?

a11y:
- Sufficient color contrast for text and UI elements (https://webaim.org/resources/contrastchecker/)
- All interactive elements are accessible via keyboard navigation
- All images and icons have appropriate alt-text or aria-labels
- Headings are used in a logical order (h1, h2, h3...)
- Forms have associated labels and clear error messages
- No keyboard traps (user can navigate away from all elements)
- Focus indicators are visible for interactive elements
- Dynamic content updates are announced to assistive technologies
- Check the console for AXE linter issues
-->

## Description
‼️ **Requires** Opetushallitus/jod-design-system/pull/584

- Update `@jod/design-system`
- Update color tokens usage


<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-2133
